### PR TITLE
Fix 'Connection Is Not Secure' Firefox warning

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,7 +61,7 @@
           <div class="g-plus" data-action="share" data-annotation="bubble" data-href="https://cpppatterns.com/"></div>
         </div>
         <div class="column-1 offset-1 about">
-          <img src="http://josephmansfield.uk/images/logo.svg">
+          <img src="https://josephmansfield.uk/images/logo.svg">
           <p>C++ Patterns created by <a href="http://josephmansfield.uk/">Joseph Mansfield</a></p>
         </div>
       </div>


### PR DESCRIPTION
Firefox warns with a warning sign attached to the lock icon in the URL
bar when some resources of a HTTPS page are loaded over HTTP.

In this case the offending resource is a SVG file - which is also
available over HTTPS, such this fix.

SVGs apparently may contain all kind of stuff like Javascript, thus
it's probably sensible for Firefox warning about it.